### PR TITLE
Expose GenerateHeader() directly

### DIFF
--- a/generateHMAC.go
+++ b/generateHMAC.go
@@ -17,7 +17,7 @@ func GenerateAuthHeader(credsFile, httpMethod, url string) (string, error) {
 		return "", err
 	}
 
-	headerValue, err := generateHeader(host, params, httpMethod, credentials[0], credentials[1], defaultAuthScheme)
+	headerValue, err := GenerateHeader(host, params, httpMethod, credentials[0], credentials[1], defaultAuthScheme)
 	if err != nil {
 		return "", err
 	}

--- a/vcodeHMACAuth.go
+++ b/vcodeHMACAuth.go
@@ -10,7 +10,7 @@ import (
 
 const defaultAuthScheme = "VERACODE-HMAC-SHA-256"
 
-func generateHeader(host, path, method, apiKeyID, apiKeySecret, authScheme string) (string, error) {
+func GenerateHeader(host, path, method, apiKeyID, apiKeySecret, authScheme string) (string, error) {
 	signingData := formatSigningData(apiKeyID, host, path, method)
 	timestamp := getCurrentTimestamp()
 	nonce := generateNonce()

--- a/vcodeHMACAuth.go
+++ b/vcodeHMACAuth.go
@@ -10,6 +10,11 @@ import (
 
 const defaultAuthScheme = "VERACODE-HMAC-SHA-256"
 
+// Generates the Authorization header to pass into the API call
+// host is usually api.veracode.com, path is in the form /path/to/function
+// method is GET, PUT, POST, or DELETE
+// the API key and secret must be set
+// authScheme is VERACODE-HMAC-SHA-256
 func GenerateHeader(host, path, method, apiKeyID, apiKeySecret, authScheme string) (string, error) {
 	signingData := formatSigningData(apiKeyID, host, path, method)
 	timestamp := getCurrentTimestamp()


### PR DESCRIPTION
This change exposes GenerateHeader directly so that it can be used directly without having to pass in a file containing the credentials.